### PR TITLE
Fix config autogenerate

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -40,6 +40,7 @@ tasks:
 
     deps: 
       - build
+      - config
 
     cmds:
     - ./bieterrunde
@@ -54,24 +55,10 @@ tasks:
 
   config:
     desc: |
-      Creates the config file
-
-        Example: task config admin_password="my password"
-
-        Variables:
-        - admin_password   (default: admin)
-        - listen_addr      (default: :9600)
-
-    vars:
-      DEFAULT_ADMIN_PASS: admin
-      DEFAULT_LISTEN_ADDR: :9600
+      Creates the config file with default values.
 
     cmds:
-      - |
-        cat << EOF > config.toml
-        admin_password = "{{or .admin_password .DEFAULT_ADMIN_PASS}}"
-        listen_addr = "{{or .listen_addr .DEFAULT_LISTEN_ADDR}}"
-        EOF
+      - go run tools/config/main.go > config.toml
 
     sources:
     - Taskfile.yml

--- a/server/config.go
+++ b/server/config.go
@@ -15,7 +15,8 @@ type Config struct {
 	ListenAddr string `toml:"listen_addr"`
 }
 
-func defaultConfig() Config {
+// DefaultConfig returns a config object with default values.
+func DefaultConfig() Config {
 	return Config{
 		ListenAddr: ":9600",
 	}
@@ -23,7 +24,7 @@ func defaultConfig() Config {
 
 // LoadConfig loads the config from a toml file.
 func LoadConfig(file string) (Config, error) {
-	c := defaultConfig()
+	c := DefaultConfig()
 
 	f, err := os.Open(file)
 	if err != nil {

--- a/tools/config/main.go
+++ b/tools/config/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/ostcar/bieterrunde/server"
+	"github.com/pelletier/go-toml/v2"
+)
+
+func main() {
+	c := server.DefaultConfig()
+	c.AdminPW = "admin"
+
+	if err := toml.NewEncoder(os.Stdout).Encode(c); err != nil {
+		log.Fatalf("Error encoding config: %v", err)
+	}
+}


### PR DESCRIPTION
@Stauberle Das automatische erstellen der configuration müsste jetzt funktionieren. Könntest du folgendes ausführen und mir Bescheid geben, ob es unter windows funktioniert?

```
task clean
task start --watch
```